### PR TITLE
Fix Sodium Sticker Rendering, Allow Adventure Mode Sticker Use

### DIFF
--- a/src/main/java/im/f24/stickerbomb/StickerBombMod.java
+++ b/src/main/java/im/f24/stickerbomb/StickerBombMod.java
@@ -7,6 +7,7 @@ import im.f24.stickerbomb.network.PrinterScreenProvideIDC2SPayload;
 import im.f24.stickerbomb.screen.PrinterScreenHandler;
 import im.f24.stickerbomb.stickers.components.StickerChunkComponent;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
@@ -16,6 +17,7 @@ import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroups;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
@@ -78,6 +80,15 @@ public class StickerBombMod implements ModInitializer {
 			AbstractBlock.Settings.create(),
 			true
 		);
+
+		ItemGroupEvents.modifyEntriesEvent(ItemGroups.FUNCTIONAL).register(group -> {
+			group.add(STICKER_PRINTER_BLOCK);
+		});
+
+		ItemGroupEvents.modifyEntriesEvent(ItemGroups.TOOLS).register(group -> {
+			group.add(BLANK_STICKER_ITEM);
+			group.add(STICKER_SCRAPER_ITEM);
+		});
 
 		PRINTER_SCREEN_HANDLER = Registry.register(Registries.SCREEN_HANDLER, Identifier.of(ID, "printer"),
 			new ScreenHandlerType<>(PrinterScreenHandler::new, FeatureFlags.VANILLA_FEATURES));

--- a/src/main/java/im/f24/stickerbomb/client/render/StickerRenderer.java
+++ b/src/main/java/im/f24/stickerbomb/client/render/StickerRenderer.java
@@ -40,12 +40,15 @@ public class StickerRenderer {
 		if (FabricLoader.getInstance().isModLoaded("sodium")) {
 			//TODO - See if we can optimize this?..
 			var renderDistance = (int) worldRenderer.getViewDistance();
+			var cameraChunk = ChunkSectionPos.from(camera.getBlockPos());
+			var cameraX = cameraChunk.getX();
+			var cameraZ = cameraChunk.getZ();
 
-			for (var x = -renderDistance; x <= renderDistance; x++) {
-				for (var z = -renderDistance; z <= renderDistance; z++) {
+			for (var x = cameraX - renderDistance; x <= cameraX + renderDistance; x++) {
+				for (var z = cameraZ - renderDistance; z <= cameraZ + renderDistance; z++) {
 					var chunk = world.getChunk(x, z);
 
-					for (var y = 0; y < world.countVerticalSections(); y++) {
+					for (var y = world.getBottomSectionCoord(); y < world.countVerticalSections(); y++) {
 						var sectionBox = Box.enclosing(
 							chunk.getPos().getBlockPos(0, y * 16, 0),
 							chunk.getPos().getBlockPos(16, (y + 1) * 16, 16)

--- a/src/main/java/im/f24/stickerbomb/mixin/ItemStackMixin.java
+++ b/src/main/java/im/f24/stickerbomb/mixin/ItemStackMixin.java
@@ -1,0 +1,28 @@
+package im.f24.stickerbomb.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import im.f24.stickerbomb.items.StickerItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.ItemUsageContext;
+import net.minecraft.world.GameMode;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(ItemStack.class)
+public abstract class ItemStackMixin {
+	
+	@Shadow
+	public abstract Item getItem();
+
+	@ModifyExpressionValue(method = "useOnBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;canPlaceOn(Lnet/minecraft/block/pattern/CachedBlockPosition;)Z"))
+	public boolean stickerbomb$allowStickersInAdventureMode(boolean original, ItemUsageContext context) {
+		if(this.getItem() instanceof StickerItem) {
+			return true;
+		}
+
+		return original;
+	}
+
+}

--- a/src/main/resources/stickerbomb.mixins.json
+++ b/src/main/resources/stickerbomb.mixins.json
@@ -4,6 +4,7 @@
   "package": "im.f24.stickerbomb.mixin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
+    "ItemStackMixin"
   ],
   "client": [
     "MinecraftClientMixin"


### PR DESCRIPTION
Fixes sticker rendering beyond spawn chunks when Sodium is installed, allows stickers (but not the sticker scraper) to be used in adventure mode. Also adds mod items to the creative inventory, with the printer going in the Functional tab, and the blank sticker and sticker scraper going into the Tools tab (I didn't include the normal sticker item, but can change that if wanted).

This has been tested on the ModFest Toybox Test Pack (singleplayer only). Let me know if I need to make any other changes!